### PR TITLE
Updated GTA2Net project

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -718,7 +718,7 @@
     - name: gta2net
       url: http://code.google.com/p/gta2net/
       repo: http://code.google.com/p/gta2net/source/browse/trunk
-      info: active development, .NET
+      info: development halted, C#
       added: 2014-02-05
 
 


### PR DESCRIPTION
It was a one-man project that was abandoned https://code.google.com/p/gta2net/source/list. Usage of @MonoGame indicates this is not restricted to Windows.