### PR TITLE
Use the correct mode when generating anchors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
     <input id="filter" type="text" placeholder="Type to filter by name or information">
   </div>
 
-{% macro render_name(name, idx) %}
+{% macro render_name(name, idx, mode) %}
   {%- if name|length == 2 -%}
     {% set name, wiki = name %}
   {%- else -%}
@@ -63,7 +63,7 @@
 
 {% macro render(names, items, mode) %}
   {% for name in names %}
-    {{ render_name(name, loop.index0) }}
+    {{ render_name(name, loop.index0, mode) }}
   {% endfor %}
 
   {% for game in items %}


### PR DESCRIPTION
Apparently `render_name` doesn’t inherit the value of `mode` from the `render` macro, so we have to specifically pass it along. This will fix anchors for the games that exist in both modes, previously they wouldn’t include the mode and always link to the clones and never to the ‘inspired by’ section.