### PR TITLE
Update the repo and url entry of projects that left sourceforge.

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -2296,7 +2296,7 @@
       added: 2015-05-09
       url: http://sourceforge.net/projects/maxit/
       info: sporadic development, C++, BSD
-      repo: svn://svn.code.sf.net/p/maxit/code/
+      repo: https://github.com/textbrowser/maxit
       media:
         - url: https://a.fsdn.com/con/app/proj/maxit/screenshots/183592.jpg/182/137
           image: https://a.fsdn.com/con/app/proj/maxit/screenshots/183592.jpg
@@ -3968,18 +3968,22 @@
         - url: http://picload.org/image/llawpia/openraider_old.png
           image: http://picload.org/thumbnail/llawpia/openraider_old.png
     - name: OpenTomb
-      url: http://sourceforge.net/projects/opentomb/
-      repo: http://sourceforge.net/p/opentomb/code/ci/default/tree/
+      url: https://opentomb.github.io/
+      repo: https://github.com/opentomb/OpenTomb
       info: active development, C++
       added: 2013-06-06
       media:
         - raw: <iframe width="420" height="315" src="http://www.youtube.com/embed/Jf3JGm67oS0?rel=0" frameborder="0" allowfullscreen></iframe>
-        - url: http://a.fsdn.com/con/app/proj/opentomb/screenshots/screen_00003.jpg
-          image: http://a.fsdn.com/con/app/proj/opentomb/screenshots/screen_00003.jpg/182/137
-        - url: http://a.fsdn.com/con/app/proj/opentomb/screenshots/object%20interaction%202.jpg
-          image: http://a.fsdn.com/con/app/proj/opentomb/screenshots/object%20interaction%202.jpg/182/137
-        - url: http://a.fsdn.com/con/app/proj/opentomb/screenshots/tr5_support.jpg
-          image: http://a.fsdn.com/con/app/proj/opentomb/screenshots/tr5_support.jpg/182/137
+        - url: https://opentomb.github.io/img/media/01.png
+          image: https://opentomb.github.io/img/media/01.png
+        - url: https://opentomb.github.io/img/media/02.png
+          image: https://opentomb.github.io/img/media/02.png
+        - url: https://opentomb.github.io/img/media/03.png
+          image: https://opentomb.github.io/img/media/03.png
+        - url: https://opentomb.github.io/img/media/06.png
+          image: https://opentomb.github.io/img/media/06.png
+        - url: https://opentomb.github.io/img/media/04.png
+          image: https://opentomb.github.io/img/media/04.png
 
 
 - name: [Touhou, Touhou Project]
@@ -4721,17 +4725,21 @@
 
 - name: Dungeon Keeper
   reimplementations:
-    - url: http://opendungeons.sourceforge.net/
+    - url: https://opendungeons.github.io/
       name: OpenDungeons
       info: active development, C++
-      repo: http://opendungeons.git.sourceforge.net/git/gitweb.cgi?p=opendungeons/opendungeons;a=shortlog;h=refs/heads/development
+      repo: https://github.com/OpenDungeons/OpenDungeons
       media:
-        - image: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S01-thumb.jpg
-          url: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S01.jpg
-        - image: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S02-thumb.jpg
-          url: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S02.jpg
-        - image: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S03-thumb.jpg
-          url: http://opendungeons.sourceforge.net/public/images/screenshots/0_4_8_S03.jpg
+        - image: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_attacking.jpg
+          url: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_attacking.jpg
+        - image: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_dungeon_and_skullflags.jpg
+          url: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_dungeon_and_skullflags.jpg
+        - image: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_mainnewsimg.png
+          url: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_mainnewsimg.png
+        - image: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_research%20tree.jpg
+          url: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_research%20tree.jpg
+        - image: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_rooms.jpg
+          url: https://raw.githubusercontent.com/OpenDungeons/opendungeons.github.io/master/media/images/0.5.0_rooms.jpg
 
 
 - names:


### PR DESCRIPTION
I just had a look at the projects that moved out of sourceforge as you may have heard recent news. I saw that Maxit, OpenTomb and OpenDungeons moved to GitHub. Here is the patch with updated url, repo and images.