### PR TITLE
Add opendf, a Daggerfall clone.

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -1377,6 +1377,10 @@
       repo: https://github.com/Burton-Radons/Daggerfall.NET
       info: stalled development, C#
       added: 2015-04-05
+    - name: opendf
+      repo: https://github.com/kcat/opendf
+      info: active development, C++, GPL3, not playable
+      added: 2015-07-17
 
 - name: "The Elder Scrolls III: Morrowind"
   clones:


### PR DESCRIPTION
I just crossed this today, it's a really new project (20 days old, but pushed publicly 2 days ago at that time of this writing) and nothing is really working at the moment on my machine (edit: I was able to, it just loads the first dungeon geometry with basic sprites and textures).
The author also appear to be the main maintainer of openal-soft and participated in OpenMW, a Morrowind clone.

More discussion could be found here: https://forum.openmw.org/viewtopic.php?f=2&t=2981

By seeing how new this project is, I do not really know if it should be merged in your page or not. Just follow your heart :-)

Have a nice day.