### PR TITLE
Add Doom 3 clones.

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -1133,6 +1133,17 @@
       added: 2015-04-12
       info: halted development, C++, GPL2, iOS
 
+- name: [Doom 3, Doom_3]
+  clones:
+    - name: dhewm3
+      added: 2015-07-29
+      repo: https://github.com/dhewm/dhewm3
+      info: active development, C++, GPL3
+    - name: RBDOOM-3-BFG
+      added: 2015-07-29
+      repo: https://github.com/RobertBeckebans/RBDOOM-3-BFG
+      info: active development, C++, GPL3, BFG edition only
+
 - name: Drugwars
   clones:
     - name: Dope Wars


### PR DESCRIPTION
This is pretty self explanatory.
The first port is only for the first edition only and the second is only for the BFG edition.

I am open to change anything that will suit your needs.
Have a good day.