### PR TITLE
Don't add link if game has no url

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
                   {{ game['info']|lower|e }}">
     <span class="{% if 'media' in game %}toggler{% else %}notoggler{% endif %}">&#x25b6;</span>
 
-    <a href="{{ game['url'] }}">{{ game['name'] }}</a> - {{ game['info'] }}
+    {%- if 'url' in game %}<a href="{{ game['url'] }}">{% endif %}{{ game['name'] }}{%- if 'url' in game %}</a>{% endif %} - {{ game['info'] }}
     {%- if 'repo' in game %} (<a href="{{ game['repo'] }}">repository</a>){% endif %}.
 
     <script type="text/screenshots">


### PR DESCRIPTION
Lots of games don't have URLs so the link created is simply the current page - osgameclones.com - so clicking them just reloads the page, which is confusing.