### PR TITLE
Remove Sing engine(Half-Life)

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -1907,15 +1907,6 @@
       media:
         - raw: <iframe width="420" height="315" src="//www.youtube.com/embed/JBjdzWomC4M?rel=0" frameborder="0" allowfullscreen></iframe>
 
-
-- name: [Half-Life, Half-Life (video game)]
-  clones:
-    - name: Sing
-      url: http://code.google.com/p/sing-engine/
-      repo: http://code.google.com/p/sing-engine/source/browse/trunk
-      info: development halted, C
-      added: 2013-06-08
-
 - name: Halls of the Things
   clones:
     - name: Halls of the Things 2008/2011/2014 Remake


### PR DESCRIPTION
According to #242 PR, Xash3D is not open source. (but it really open, maybe not free, but open) 
Sing engine is a fork of Xash3D. So it must be removed.