### PR TITLE
Updated OpenRA website and screenshots

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -848,13 +848,13 @@
     - Dune 2000
   clones:
     - name: OpenRA
-      url: http://www.open-ra.org
+      url: http://www.openra.net
       repo: https://github.com/OpenRA/OpenRA
       info: active development, C#
       media:
-        - image: http://media.moddb.com/cache/images/games/1/15/14718/thumb_300x150/OpenRA-20120504-CnC-Shellmap.png
-        - image: http://media.moddb.com/cache/images/games/1/15/14718/thumb_300x150/invasion.png
-        - image: http://media.moddb.com/cache/images/games/1/15/14718/thumb_300x150/d2k-ingame.png
+        - image: http://www.openra.net/images/news/20150531-ra-editor.png
+        - image: http://www.openra.net/images/news/20140405-beacons.png
+        - image: http://www.openra.net/images/news/20150808-d2k-range-circles.png
 
 - name: [Contra, Contra (video game)]
   clones:


### PR DESCRIPTION
Website changed from http://www.open-ra.org to http://www.openra.net a while ago.

I also updated the screenshots to reflect the progress of the game engine and highlight all the supported games/mods as well as the modernization regarding UI compared to the originals:

![in-game map editor Red Alert mod](http://www.openra.net/images/news/20150531-ra-editor.png)
![Tiberian Dawn mod UI and support power A10 strike](http://www.openra.net/images/news/20140405-beacons.png)
![Replay system and range indicators in the Dune 2000 mod](http://www.openra.net/images/news/20150808-d2k-range-circles.png)