### PR TITLE
Added Netacka and rawgl

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -145,7 +145,7 @@
       added: 2015-04-09
       info: halted development, C, C++, Java, Pascal, GPL2
 
-- names: 
+- names:
     - [Another World, "Another World (video game)"]
     - [Out of This World, "Another World (video game)"]
     - [Outer World (アウターワールド Autā Wārudo), "Another World (video game)"]
@@ -174,7 +174,7 @@
       media:
         - image: http://xarchon.seul.org/img/snap-1.gif
         - image: http://xarchon.seul.org/img/snap-2.gif
-        
+
 - name: "[Area 51, Area 51 (2005 video game)]"
   clones:
     - name: Project Dreamland
@@ -325,7 +325,7 @@
           url: https://a.fsdn.com/con/app/proj/openastromenace/screenshots/am7.jpg/182/137
 
 - name: Astrosmash
-  clones: 
+  clones:
     - name: Cosmosmash
       url: http://perso.b2b2c.ca/sarrazip/dev/cosmosmash.html
       added: 2015-04-16
@@ -472,7 +472,7 @@
         - image: http://a.fsdn.com/con/app/proj/xbak/screenshots/126405.jpg
         - image: http://a.fsdn.com/con/app/proj/xbak/screenshots/62665.jpg
         - image: http://a.fsdn.com/con/app/proj/xbak/screenshots/71372.jpg
-        
+
 - name: [The Binding of Isaac,  "The Binding of Isaac (video game)"]
   clones:
     - name: Witch Blast
@@ -735,7 +735,7 @@
       info: C, custom licence
 
 - name: Candy Crush Saga
-  reimplementations: 
+  reimplementations:
     - name: CookieCrunch
       repo: https://github.com/renatomcamilio/CookieCrunch
       added: 2015-05-29
@@ -1045,7 +1045,7 @@
       added: 2015-05-28
       info: halted development, (Python & Panda3D), no specified licence
 
-- name: 
+- name:
     - "DesertStrike: Return to the Gulf"
     - Jungle Strike
   clones:
@@ -1614,7 +1614,7 @@
           image: http://a.fsdn.com/con/app/proj/parpg/screenshots/286275.jpg
 
 - name: ["Fallout 3: Van Buren", "Van Buren (video game)"]
-  clones: 
+  clones:
     - name: Van Buren Project
       url: http://vanburenproject.blogspot.co.uk/
       repo: http://van-buren-project.googlecode.com/svn/trunk/
@@ -1903,10 +1903,10 @@
       url: http://slingshot.wikispot.org/
       info: Python, playable, halted development, GPL2
       media:
-          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot1.png 
-          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot2.png 
-          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot3.png 
-          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot4.png 
+          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot1.png
+          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot2.png
+          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot3.png
+          - url: http://slingshot.wikispot.org/Screenshots?sendfile=true&file=sshot4.png
 
 - name: The Great Giana Sisters
   clones:
@@ -2350,7 +2350,7 @@
       info: halted development, C++, GPL3
 
 - name: [Ladder, Ladder (video game)]
-  clones: 
+  clones:
     - name: Ladder
       added: 2015-05-09
       url: http://gamesoft.ca/remakes.html
@@ -2704,7 +2704,7 @@
         - url: https://a.fsdn.com/con/app/proj/ocmod/screenshots/75332.jpg/182/137
           image: https://a.fsdn.com/con/app/proj/ocmod/screenshots/75332.jpg
 
-- names: 
+- names:
     - Outrun
     - アウト ラン
     - Auto Ran
@@ -4015,7 +4015,7 @@
       added: 2015-04-07
       info: sporadic development, C++, custom licence (Starshatter OpenSource Distribution)
 
-- names: 
+- names:
   - [Stunts, Stunts (video game)]
   - 4D Sports Driving
   clones:
@@ -4250,7 +4250,7 @@
       repo: https://github.com/jsettlers/settlers-remake
       added: 2015-04-06
       info: active development, needs original files, Java
-      media: 
+      media:
         - image: http://www.settlers-android-clone.com/wp-content/gallery/screenshots_win7/SoldiersFighting_1.png
 
 - name: Shobon Action
@@ -4742,7 +4742,7 @@
       info: halted development, CoffeeScript, no specified licence
 
 - name: [Warlords II, "Warlords (game series)#Warlords II"]
-  clones: 
+  clones:
     - name: FreeLords
       url: http://sourceforge.net/projects/freelords/
       info: active development, Java, GPL2

--- a/games.yaml
+++ b/games.yaml
@@ -175,7 +175,7 @@
         - image: http://xarchon.seul.org/img/snap-1.gif
         - image: http://xarchon.seul.org/img/snap-2.gif
 
-- name: "[Area 51, Area 51 (2005 video game)]"
+- name: ["Area 51", "Area 51 (2005 video game)"]
   clones:
     - name: Project Dreamland
       added: 2016-04-03

--- a/games.yaml
+++ b/games.yaml
@@ -161,6 +161,16 @@
       repo: svn://svn.code.sf.net/p/newraw/code/
       added: 2014-09-05
       info: development halted, C++, GPL
+    - name: rawgl
+      url: http://cyxdown.free.fr/rawgl/
+      repo: https://github.com/cyxx/rawgl
+      added: 2016-03-06
+      info: active development, completable, C++, GPL
+      media:
+        - image: http://cyxdown.free.fr/rawgl/raw-1.png
+        - image: http://cyxdown.free.fr/rawgl/raw-2.png
+        - image: http://cyxdown.free.fr/rawgl/rawgl-1.png
+        - image: http://cyxdown.free.fr/rawgl/rawgl-2.png
 
 - name: ["Another World 2: Heart of the Alien", "Heart of the Alien"]
   clones:

--- a/games.yaml
+++ b/games.yaml
@@ -75,6 +75,12 @@
         - image: http://zatacka.sourceforge.net/img/sc1.jpg
         - image: http://zatacka.sourceforge.net/img/sc2.jpg
         - image: http://zatacka.sourceforge.net/img/sc3.jpg
+    - name: Netacka
+      added: 2016-03-06
+      url: https://pwmarcz.pl/netacka/
+      info: halted development, C
+      media:
+        - image: https://pwmarcz.pl/netacka/sshots.png
 
 - name: Age of Empires II
   clones:


### PR DESCRIPTION
Fixes a regression from https://github.com/piranha/osgameclones/pull/270 and adds rawgl which seems to be what New RAW has forked and netacka which is a multiplayer version of zattacka.