### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+Please fill out this template:
+
+```
+- name: Some Game
+  clones:
+    - name: Some Free Game
+      url: somefreegame.com
+      repo: https://github.com/foobar/SomeFreeGame
+      info: active development, playable, C++/SDL2, GPL2, requires original files
+      added: 2014-04-04
+      media:
+        - url: http://somefreegame.com/img1.jpg
+          image: http://somefreegame.com/img1_thumbnail.jpg
+        - url: http://somefreegame.com/img2.jpg
+          image: http://somefreegame.com/img2_thumbnail.jpg
+        - raw: <iframe width="320" height="240" src="//www.youtube.com/embed/abcdefg1234?rel=0" frameborder="0" allowfullscreen></iframe>
+```
+
+- Is this inspired by the original game, rather than a clone? Replace `clones` with `reimplementations` in the above template
+


### PR DESCRIPTION
Using [GitHub's issue templates](https://github.com/blog/2111-issue-and-pull-request-templates), this PR means whenever someone creates a new issue, the body is automatically filled in like this:

![image](https://cloud.githubusercontent.com/assets/1083215/13973392/773bdac6-f0f6-11e5-9151-76e8a6f20588.png)

This is so that the user can provide as much information as possible, making it easier and faster to resolve their issues.