### PR TITLE
Don't wrap language tags

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -95,7 +95,7 @@ dd + dt { margin-top: 1em; }
 .tags-active dt.active, .tags-active dd.active {display: block}
 
 .tag { display: inline-block; font-size: 12px; padding: 0 6px; margin: 0 2px;
-       color: #444; background-color: #eee; cursor: pointer; }
+       color: #444; background-color: #eee; cursor: pointer; white-space: nowrap; }
 .tag.status:hover { color: #444; background-color: #8AFF99; }
 .tag.license:hover { color: #444; background-color: #FFFF8C; }
 .tag.lang:hover { color: #444; background-color: #9CFFFF; }


### PR DESCRIPTION
Add fix to CSS so multi-word text in language tags don't use [multiple lines](https://monosnap.com/file/o8m2Am7AmJ4TaiVFjOlxtTC8PCbPiD#) with specific page widths.