### PR TITLE
Add MIT license to Daggerfall Unity

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -2002,6 +2002,7 @@
     - name: Daggerfall Unity
       url: http://www.dfworkshop.net/
       repo: https://github.com/Interkarma/daggerfall-unity
+      license: MIT
       added: 2016-05-17
       framework: Unity
 


### PR DESCRIPTION
As stated in the Daggerfall Unity [README.md](https://github.com/Interkarma/daggerfall-unity/blob/db920c11d99910f8c96055a0f2ea55f4abcf31ed/README.md#an-open-platform):

> Open source under MIT license