### PR TITLE
Remove incorrect info from opentesarenapp

### DIFF
--- a/games.yaml
+++ b/games.yaml
@@ -1972,8 +1972,6 @@
       status: unplayable
       lang: C++
       info: requires original files
-      framework: SDL2
-      license: MIT
     - name: OpenTESArena
       repo: https://github.com/afritz1/OpenTESArena
       development: active


### PR DESCRIPTION
The [opentesarenapp](https://github.com/pralinor/opentesarenapp) repository does not have a license and does not use the SDL2 framework. The WinArena portion of the project uses the [WinAPI](https://en.wikipedia.org/wiki/Windows_API) with DirectDraw.