### PR TITLE
Update Commander Genius repo

### DIFF
--- a/games/c.yaml
+++ b/games/c.yaml
@@ -215,7 +215,7 @@
   remakes:
   - name: Commander Genius
     url: http://clonekeenplus.sourceforge.net/
-    repo: http://clonekeenplus.git.sourceforge.net/git/gitweb.cgi?p=clonekeenplus/clonekeenplus;a=summary
+    repo: https://github.com/gerstrong/Commander-Genius
     development: active
     lang: C++
     images:


### PR DESCRIPTION
The SourceForge repo has not seen any changes since 2011. Github is linked on the official download site: http://clonekeenplus.sourceforge.net/download/