### PR TITLE
Clarify glPortal's development: sporadic

### DIFF
--- a/games/p.yaml
+++ b/games/p.yaml
@@ -103,8 +103,7 @@
   - name: glPortal
     url: http://glportal.de/
     repo: https://github.com/GlPortal/glPortal
-    status: playable
-    development: active
+    development: sporadic
     lang: C++
     updated: 2013-06-25
     images:


### PR DESCRIPTION
The glPortal team is pretty small and due to wrong design decisions
(which are being corrected) the project has failed to attract more
people. As a result, development is slow.

Also removes the "`status: playable`" info since the last actually
playable version is very old and does not reflect at all the recent work
that has been done on the game and its engine.

In fact, as of this commit, portals (the central game element) have been
broken for months due to the introduction of the Bullet physics
engine.