### PR TITLE
Removed Bejeweled clone and false alias of Exile

### DIFF
--- a/games/b.yaml
+++ b/games/b.yaml
@@ -171,17 +171,6 @@
     video:
       youtube: bRbQ4OaljWs
 
-- name: Bejeweled
-  meta:
-    genre: [Puzzle]
-  remakes:
-  - name: biju-game
-    updated: 2015-05-28
-    repo: https://github.com/CrociDB/biju-game
-    development: halted
-    lang: JavaScript
-    framework: CraftyJS
-
 - name: Bermuda Syndrome
   meta:
     genre: [Adventure,Platform]

--- a/games/e.yaml
+++ b/games/e.yaml
@@ -164,7 +164,6 @@
     genre: [Action,Adventure]
   names:
   - [Exile 1988, Exile (1988 video game)]
-  - Blades of Exile
   remakes:
   - name: EXILE
     updated: 2015-06-22


### PR DESCRIPTION
- Repo for clone of Bejeweled is non-existent.
- Name "Blades of Exile" is not an alias of Exile (1988) or even game based on it but a different game from Exiles series by Spiderweb Software.