### PR TITLE
Repo/site update for: OpenZelda, Twin-E, FoFiX, keeperfx

### DIFF
--- a/games/d.yaml
+++ b/games/d.yaml
@@ -560,7 +560,8 @@
     url: http://keeper.lubiki.pl/html/dk_keeperfx.php
     development: active
     lang: C
-    repo: https://code.google.com/p/keeperfx/source/list
+    repo: https://github.com/dkfans/keeperfx
+    updated: 2017-10-23
 
 - name: Dungeon Keeper 2
   meta:

--- a/games/g.yaml
+++ b/games/g.yaml
@@ -232,9 +232,8 @@
     - http://fretsonfire.sourceforge.net/screenshots/fretsonfire1.png
     - http://fretsonfire.sourceforge.net/screenshots/fretsonfire4.png
   - name: Frets on Fire X
-    url: https://code.google.com/p/fofix/
     repo: https://github.com/fofix/fofix
-    updated: 2014-09-19
+    updated: 2017-10-23
     status: playable
     development: active
     lang: Python

--- a/games/l.yaml
+++ b/games/l.yaml
@@ -110,14 +110,14 @@
     genre: [Adventure]
   remakes:
   - name: twin-e
-    url: https://code.google.com/p/twin-e/
-    repo: https://code.google.com/p/twin-e/source/browse/
+    url: https://github.com/xesf/twin-e
+    repo: https://github.com/xesf/twin-e
     status: playable
-    development: sporadic
+    development: halted
     content: commercial
     lang: C
     license: [GPL]
-    updated: 2014-11-09
+    updated: 2017-10-23
 
 - name: [Locomotion (Amiga 1992), 'http://www.mobygames.com/game/locomotion']
   meta:
@@ -305,12 +305,12 @@
     genre: [Action,Adventure]
   clones:
   - name: Open Zelda
-    url: http://openzelda.net/
-    repo: https://code.google.com/p/openzelda/
+    url: http://openzelda.nfshost.com/
+    repo: https://github.com/openzelda/openzelda-source
     status: playable
-    development: sporadic
+    development: halted
     lang: C++
-    updated: 2014-04-28
+    updated: 2017-10-23
     video:
       youtube: secXtfqKo1c
   - name: The Legend Of Zelda - Return Of The Hylan

--- a/games/w.yaml
+++ b/games/w.yaml
@@ -247,10 +247,11 @@
     genre: [TBS]
   clones:
   - url: http://hedgewars.org/
+    updated: 2017-10-23
     name: Hedgewars
     development: active
     lang: [Pascal, C++, Haskell]
-    repo: http://code.google.com/p/hedgewars/
+    repo: http://hg.hedgewars.org/hedgewars/
     images:
     - http://hedgewars.org/files/fck_upload/image/screenshots/0_9_15-main-menu_s.png
     - http://hedgewars.org/files/fck_upload/image/screenshots/0_9_15-christmas_s.png


### PR DESCRIPTION
Those projects moved out of code.google.com
piranha/osgameclones/#440
