### PR TITLE
Update OpenRCT2 Entry

### DIFF
--- a/games/r.yaml
+++ b/games/r.yaml
@@ -219,12 +219,14 @@
   - name: OpenRCT2
     url: https://openrct2.com/
     repo: https://github.com/OpenRCT2/OpenRCT2
-    updated: 2014-08-20
+    updated: 2017-10-29
     development: active
-    lang: C
+    lang: C++
     license: [GPL3]
+    status: playable
     images:
     - http://i.imgur.com/kTkK5Gw.png
+    - http://i.imgur.com/fpoZdze.png
 
 - name: Ryzom
   meta:

--- a/games/r.yaml
+++ b/games/r.yaml
@@ -225,7 +225,6 @@
     license: [GPL3]
     status: playable
     images:
-    - http://i.imgur.com/kTkK5Gw.png
     - http://i.imgur.com/fpoZdze.png
 
 - name: Ryzom


### PR DESCRIPTION
I updated the OpenRCT2 Entry to reflect the current status of the project. Is there a way, without copying and pasting of course, that I can indicate that the game is capable of replacing RollerCoaster Tycoon 1 as well? (Importing and running Scenarios/Saves/etc)

Additionally, we are technically a clone of "RollerCoaster Tycoon Classic" on iOS, Android, and Windows due to it being a re-release of the original game with a new UI on those platforms. We are also able to import this games assets as a base.